### PR TITLE
brew-formula-analytics: use formulary lookup.

### DIFF
--- a/cmd/brew-formula-analytics.rb
+++ b/cmd/brew-formula-analytics.rb
@@ -78,17 +78,22 @@ dimension_filter_clauses = [
 ]
 
 if formula
+  formula_name = begin
+    Formula[formula].full_name
+  rescue
+    formula
+  end
   dimension_filter_clauses << DimensionFilterClause.new(
     operator: "OR",
     filters: [
       DimensionFilter.new(
         dimension_name: "ga:eventAction",
-        expressions: [formula],
+        expressions: [formula_name],
         operator: "EXACT",
       ),
       DimensionFilter.new(
         dimension_name: "ga:eventAction",
-        expressions: ["#{formula} "],
+        expressions: ["#{formula_name} "],
         operator: "BEGINS_WITH",
       ),
     ],


### PR DESCRIPTION
Lookup formulae names from the currently tapped taps to save a little bit of typing.

CC @ilovezfs who requested this.