### PR TITLE
Allow more categories to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Homebrew Formula Analytics
-Provides `brew formula-analytics` for Homebrew maintainers to be able to query [Homebrew's analytics](http://docs.brew.sh/Analytics.html) from the command-line.
+Provides `brew formula-analytics` for Homebrew maintainers to be able to query [Homebrew's analytics](https://docs.brew.sh/Analytics.html) from the command-line.
 
 This is restricted to maintainers only because it's not clear how to provide anonymous, read-only access to Google Analytics.
 


### PR DESCRIPTION
Allow multiple categories to be specified at once and add a new `--os-version` argument to query based on OS version rather than formula.

Also, while we're here update an HTTP link to HTTPS and cleanup an outdated RuboCop rule, too.