### PR TITLE
formula-analytics: handle no formula arguments.

### DIFF
--- a/cmd/brew-formula-analytics.rb
+++ b/cmd/brew-formula-analytics.rb
@@ -71,7 +71,11 @@ end
 json_output = ARGV.include?("--json")
 os_version = ARGV.include?("--os-version")
 
-formulae = ARGV.named
+formulae = if !ARGV.named.empty?
+  ARGV.named
+else
+  [nil]
+end
 
 categories = []
 categories << :install if ARGV.include?("--install")


### PR DESCRIPTION
In that case we want to ensure that we still search for something so provide a single `nil` in the formulae array so the formulae loop runs at least once but without a formula conditional.

Fixes #14