### PR TITLE
brew-formula-analytics: refuse to run with HOMEBREW_NO_ANALYTICS set.

### DIFF
--- a/cmd/brew-formula-analytics.rb
+++ b/cmd/brew-formula-analytics.rb
@@ -58,6 +58,10 @@ unless File.exist? CREDENTIALS_PATH
   odie "No Google Analytics credentials found at #{CREDENTIALS_PATH}!"
 end
 
+if ENV["HOMEBREW_NO_ANALYTICS"]
+  odie "HOMEBREW_NO_ANALYTICS is set!"
+end
+
 # Using a service account:
 # https://developers.google.com/api-client-library/ruby/auth/service-accounts
 credentials = ServiceAccountCredentials.make_creds(


### PR DESCRIPTION
It's not reasonable to want to query analytics from users but not provide analytics yourself.