### PR TITLE
Set a `--linux` flag to use the 'Linuxbrew' analytics account

### DIFF
--- a/cmd/brew-formula-analytics.rb
+++ b/cmd/brew-formula-analytics.rb
@@ -19,6 +19,7 @@
 #:
 #:    If `--setup` is passed, install the necessary gems and require them and exit once that is done.
 #:
+#:    If `--linux` is passed, read analytics from Linuxbrew's Google Analytics account.
 
 # Configure RubyGems.
 require "rubygems"
@@ -46,7 +47,12 @@ include Google::Apis::AnalyticsreportingV4
 include Google::Auth
 # rubocop:enable Style/MixinUsage
 
-ANALYTICS_VIEW_ID = "120682403".freeze
+ANALYTICS_VIEW_ID = if ARGV.include?("--linux")
+  "120391035"
+else
+  "120682403"
+end.freeze
+
 API_SCOPE = "https://www.googleapis.com/auth/analytics.readonly".freeze
 
 # https://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/AnalyticsreportingV4/AnalyticsReportingService


### PR DESCRIPTION
- Previously, the `ANALYTICS_VIEW_ID` was hardcoded to point to the
  Homebrew one (120682403).
- Homebrew on Linux has its own Google Analytics account, with its own
  view ID.
- I did consider a one-liner:
  `ANALYTICS_VIEW_ID = ARGV.include?("--linux") ? "12345" : "67890".freeze`
  but it seemed easier to read with the full `if` syntax.
- I also considered using `OS.mac?` and `OS.linux?`, but that would have
  been messy if people on either of those OSes wanted to access the
  others' GA data.