### PR TITLE
cmd/formula-analytics: display Big Sur; relax major version regex

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -303,7 +303,8 @@ module Homebrew
     when "10.13" then "macOS High Sierra (10.13)"
     when "10.14" then "macOS Mojave (10.14)"
     when "10.15" then "macOS Catalina (10.15)"
-    when /10\.\d+/ then "macOS (#{dimension})"
+    when "10.16", "11.0" then "macOS Big Sur (#{dimension})"
+    when /\d+\.\d+/ then "macOS (#{dimension})"
     when "" then "Unknown"
     else dimension
     end


### PR DESCRIPTION
Note that I do not get a single result for 11.0 or for any system other than "Intel" for that matter.

I suspect Google Analytics might not yet support such user-agents yet. Either that or Apple have done a flawless job at hiding everything and have been using `HOMEBREW_NO_ANALYTICS` on all Apple Silicon machines - I guess we'll see when people start receiving dev kits.