### PR TITLE
Adjust macOS version logic

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -305,7 +305,7 @@ module Homebrew
     when "10.13" then "macOS High Sierra (10.13)"
     when "10.14" then "macOS Mojave (10.14)"
     when "10.15" then "macOS Catalina (10.15)"
-    when "10.16", "11.0" then "macOS Big Sur (#{dimension})"
+    when "10.16", /^11\./ then "macOS Big Sur (11)"
     when /\d+\.\d+/ then "macOS (#{dimension})"
     when "" then "Unknown"
     else dimension


### PR DESCRIPTION
As per Homebrew/brew#9225, consider any macOS version number starting with 11 to be Big Sur.

One question: do we also want to collapse all 11.x versions into a single entry, or keep them separate as they currently appear at https://formulae.brew.sh/analytics/os-version/30d/?