### PR TITLE
cmd/formula-analytics: fix Big Sur version.

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -305,7 +305,7 @@ module Homebrew
     when "10.13" then "macOS High Sierra (10.13)"
     when "10.14" then "macOS Mojave (10.14)"
     when "10.15" then "macOS Catalina (10.15)"
-    when "10.16", /^11\./ then "macOS Big Sur (11)"
+    when "10.16", /^11\./ then "macOS Big Sur (#{dimension})"
     when /\d+\.\d+/ then "macOS (#{dimension})"
     when "" then "Unknown"
     else dimension


### PR DESCRIPTION
Otherwise there's multiple `macOS Big Sur (11)` entries on https://formulae.brew.sh/analytics/os-version/30d/