### PR TITLE
Gemfile*: use google-apis-analyticsreporting_v4 gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "google-api-client"
+gem "google-apis-analyticsreporting_v4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.2.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     faraday (1.3.0)
@@ -17,10 +10,8 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
-    gems (1.2.0)
-    google-api-client (0.53.0)
+    google-apis-analyticsreporting_v4 (0.1.0)
       google-apis-core (~> 0.1)
-      google-apis-generator (~> 0.1)
     google-apis-core (0.2.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.14)
@@ -31,14 +22,6 @@ GEM
       rexml
       signet (~> 0.14)
       webrick
-    google-apis-discovery_v1 (0.1.0)
-      google-apis-core (~> 0.1)
-    google-apis-generator (0.1.2)
-      activesupport (>= 5.0)
-      gems (~> 1.2)
-      google-apis-core (~> 0.1)
-      google-apis-discovery_v1 (~> 0.0)
-      thor (>= 0.20, < 2.a)
     googleauth (0.15.1)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
@@ -47,12 +30,9 @@ GEM
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
     httpclient (2.8.3)
-    i18n (1.8.9)
-      concurrent-ruby (~> 1.0)
     jwt (2.2.2)
     memoist (0.16.2)
     mini_mime (1.0.2)
-    minitest (5.14.3)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     os (1.1.1)
@@ -69,18 +49,14 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    thor (1.1.0)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
     uber (0.1.0)
     webrick (1.7.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  google-api-client
+  google-apis-analyticsreporting_v4
 
 BUNDLED WITH
-   1.14.6
+   1.17.3


### PR DESCRIPTION
This is the new/currently updated one.