### PR TITLE
Revert "build(deps): bump declarative-option from 0.1.0 to 0.1.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     declarative (0.0.20)
-    declarative-option (0.1.1)
+    declarative-option (0.1.0)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)


### PR DESCRIPTION
0.1.1 has been yanked, breaking the formulae.brew.sh build.

Reverts Homebrew/homebrew-formula-analytics#220