### PR TITLE
Start work on reading analytics from InfluxDB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source "https://rubygems.org"
 
 gem "google-apis-analyticsreporting_v4"
+gem "influxdb-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     httpclient (2.8.3)
+    influxdb-client (2.9.0)
     jwt (2.7.0)
     memoist (0.16.2)
     mini_mime (1.1.2)
@@ -54,6 +55,7 @@ PLATFORMS
 
 DEPENDENCIES
   google-apis-analyticsreporting_v4
+  influxdb-client
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Adds a hidden `--influx` argument to read the analytics from InfluxDB rather than Google Analytics.

Merging this as-is so future PRs can focus on building out the data and we can ensure we don't get regressions here.