### PR TITLE
cmd/formula-analytics: fix default InfluxDB encoding

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -387,7 +387,7 @@ module Homebrew
           |> group(columns: ["#{tag}"])
           |> sum(column: "_value")
       EOS
-      result = influxdb_client.create_query_api.query_raw(query: query)
+      result = influxdb_client.create_query_api.query_raw(query: query).force_encoding("UTF-8")
       lines = result.lines.drop(4)
       json = {
         category:    category,


### PR DESCRIPTION
Fixes https://github.com/Homebrew/formulae.brew.sh/actions/runs/5193660963/jobs/9364484761#step:6:87