### PR TITLE
cmd/formula-analytics: invoke bundle install if local install is stale

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -59,9 +59,8 @@ module Homebrew
     # Configure RubyGems.
     require "rubygems"
 
-    unless BUNDLER_SETUP.exist?
-      Homebrew.install_bundler!
-
+    Homebrew.install_bundler!
+    if !BUNDLER_SETUP.exist? || !quiet_system("bundle", "check", "--path", "vendor/ruby")
       REPO_ROOT.cd do
         safe_system "bundle", "install", "--standalone", "--path", "vendor/ruby"
       end


### PR DESCRIPTION
Updates to Gemfile.lock currently don't take place unless you delete `vendor` yourself.

This PR makes the code smarter by running a `bundle check` to see if an install is needed. This doesn't matter for CI, but did for me locally when I ran this command for the first time in months.

Requires https://github.com/Homebrew/brew/pull/15532 for `Homebrew.install_bundler!` not to be a slowdown.