### PR TITLE
formula-analytics: more Ubuntu version cleanup.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - ../../../.rubocop.yml

--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -506,6 +506,7 @@ module Homebrew
     when /^12\.?/ then "macOS Monterey (12)"
     when /^13\.?/ then "macOS Ventura (13)"
     when /^14\.?/ then "macOS Sonoma (14)"
+    when /Ubuntu(-Server)? (14|16|18|20|22)\.04/ then "Ubuntu #{Regexp.last_match(2)}.04 LTS"
     when /Ubuntu(-Server)? (\d+\.\d+).\d ?(LTS)?/ then "Ubuntu #{Regexp.last_match(2)} #{Regexp.last_match(3)}".strip
     else dimension
     end


### PR DESCRIPTION
We know which versions are always LTS to consolidate them.

While we're here, add a stub `.rubocop.yml` to make `rubocop` do the right thing.