### PR TITLE
cmd: more InfluxDB changes.

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -475,6 +475,8 @@ module Homebrew
           item[:count] = format_count(item[:count])
 
           formula_name = item[dimension_key]
+          next if formula_name.include?("/")
+
           core_formula_items[formula_name] ||= []
           core_formula_items[formula_name] << item
         end

--- a/cmd/generate-analytics-api.rb
+++ b/cmd/generate-analytics-api.rb
@@ -121,13 +121,7 @@ module Homebrew
         DAYS.each do |days|
           next if days != "30" && category_name == "build-error" && !data_source.nil?
 
-          args = %W[--days-ago=#{days}]
-          if days == "30"
-            args << "--influxdb"
-          elsif os == :linux
-            args << "--linux"
-          end
-
+          args = %W[--influxdb --days-ago=#{days}]
           output = run_formula_analytics(*formula_analytics_args, *args)
           (analytics_data_path/"#{days}d.json").write output
           (analytics_api_path/"#{days}d.json").write analytics_json_template(category_name, data_source: data_source)


### PR DESCRIPTION
- skip tap formulae when generating homebrew/core JSON
- always use InfluxDB when generating analytics data