### PR TITLE
cmd/generate-analytics-api: remove merged_output

### DIFF
--- a/cmd/generate-analytics-api.rb
+++ b/cmd/generate-analytics-api.rb
@@ -55,7 +55,7 @@ module Homebrew
       result = Utils.popen_read(HOMEBREW_BREW_FILE, "formula-analytics", *args)
     end
 
-    odie "`brew formula-analytics #{args.join(" ")}` failed: #{result.merged_output}" unless $CHILD_STATUS.success?
+    odie "`brew formula-analytics #{args.join(" ")}` failed: #{result}" unless $CHILD_STATUS.success?
 
     result
   end

--- a/cmd/generate-analytics-api.rb
+++ b/cmd/generate-analytics-api.rb
@@ -44,7 +44,7 @@ module Homebrew
     puts "brew formula-analytics #{args.join(" ")}"
 
     retries = 0
-    result = Utils.popen_read(HOMEBREW_BREW_FILE, "formula-analytics", *args)
+    result = Utils.popen_read(HOMEBREW_BREW_FILE, "formula-analytics", *args, err: :err)
 
     while !$CHILD_STATUS.success? && retries < MAX_RETRIES
       # Give InfluxDB some more breathing room.
@@ -52,7 +52,7 @@ module Homebrew
 
       retries += 1
       puts "Retrying #{args.join(" ")} (#{retries}/#{MAX_RETRIES})..."
-      result = Utils.popen_read(HOMEBREW_BREW_FILE, "formula-analytics", *args)
+      result = Utils.popen_read(HOMEBREW_BREW_FILE, "formula-analytics", *args, err: :err)
     end
 
     odie "`brew formula-analytics #{args.join(" ")}` failed: #{result}" unless $CHILD_STATUS.success?


### PR DESCRIPTION
Just a quick fix for https://github.com/Homebrew/formulae.brew.sh/issues/1104

Not sure how to reproduce original `result.merged_output` behavior. By default `Utils.popen_read` sends stderr to `/dev/null`. 

Did try a `StringIO` but wasn't successful, e.g.
```rb
stderr = StringIO.new
result = Utils.popen_read(..., err: stderr)
```
I was able to get some stderr via `IO.pipe` but not sure if best way, e.g.
```rb
stderr = ""
IO.pipe do |rd, wr|
  result = Utils.popen_read(..., err: wr)
  wr.close
  stderr = rd.read
end
```