### PR TITLE
cmd/generate-analytics-api: remove command-run-options, test-bot-test.

### DIFF
--- a/cmd/generate-analytics-api.rb
+++ b/cmd/generate-analytics-api.rb
@@ -11,9 +11,9 @@ module Homebrew
     cask-install core-cask-install os-version
     homebrew-devcmdrun-developer homebrew-os-arch-ci
     homebrew-prefixes homebrew-versions
-    brew-command-run brew-command-run-options
-    brew-test-bot-test
+    brew-command-run
   ].freeze
+  # TODO: add brew-command-run-options brew-test-bot-test to above when working.
   DAYS = %w[30 90 365].freeze
   MAX_RETRIES = 3
 


### PR DESCRIPTION
These aren't generating valid data yet so let's avoid attempting any generation for now.