### PR TITLE
Gemfile: use `.ruby-version`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@
 
 source "https://rubygems.org"
 
+ruby file: ".ruby-version"
+
 gem "influxdb-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,3 +8,9 @@ PLATFORMS
 
 DEPENDENCIES
   influxdb-client
+
+RUBY VERSION
+   ruby 3.3.1p55
+
+BUNDLED WITH
+   2.5.9


### PR DESCRIPTION
This ensures it's used consistently by `bundle`.