### PR TITLE
Allow Portable Ruby to mismatch .ruby-version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby file: ".ruby-version"
+ruby file: ".ruby-version" unless ENV.key?("HOMEBREW_BREW_FILE")
 
 gem "influxdb-client"

--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -67,8 +67,10 @@ module Homebrew
 
     Homebrew.install_bundler!
     REPO_ROOT.cd do
-      if !BUNDLER_SETUP.exist? || !quiet_system("bundle", "check", "--path", "vendor/ruby")
-        safe_system "bundle", "install", "--standalone", "--path", "vendor/ruby", out: :err
+      with_env(BUNDLE_PATH: "vendor/ruby", BUNDLE_FROZEN: "true") do
+        if !BUNDLER_SETUP.exist? || !quiet_system("bundle", "check")
+          safe_system "bundle", "install", "--standalone", out: :err
+        end
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/formulae.brew.sh/issues/1212