### PR TITLE
cmd/formula-analytics: fix KDE neon handling

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -389,7 +389,7 @@ module Homebrew
         when %r{Debian GNU/Linux (\d+)\.\d+} then "Debian #{Regexp.last_match(1)} #{Regexp.last_match(2)}"
         when /CentOS (\w+) (\d+)/ then "CentOS #{Regexp.last_match(1)} #{Regexp.last_match(2)}"
         when /Fedora Linux (\d+)[.\d]*/ then "Fedora Linux #{Regexp.last_match(1)}"
-        when /KDE neon .*([\d.]+)/ then "KDE neon #{Regexp.last_match(1)}"
+        when /KDE neon .*?([\d.]+)/ then "KDE neon #{Regexp.last_match(1)}"
         else dimension
         end
       end


### PR DESCRIPTION
It was mapping `KDE neon 6.0` to `KDE neon 0` which doesn't make sense. Make the regex non-greedy.