### PR TITLE
cmd/generate-analytics-api: generate more analytics.

### DIFF
--- a/cmd/generate-analytics-api.rb
+++ b/cmd/generate-analytics-api.rb
@@ -11,7 +11,7 @@ module Homebrew
         cask-install core-cask-install os-version
         homebrew-devcmdrun-developer homebrew-os-arch-ci
         homebrew-prefixes homebrew-versions
-        brew-command-run
+        brew-command-run brew-command-run-options brew-test-bot-test
       ].freeze
 
       # TODO: add brew-command-run-options brew-test-bot-test to above when working.


### PR DESCRIPTION
Output `brew-command-run-options` and `brew-test-bot-test` analytics now that they are working.

While we're here:
- improve the unauthenticated error message to be more helpful.
- remove `--with*` options from the command output
- remove TODO comments for cleanup of bad data that can't been done.