### PR TITLE
The `dimension` param can be blank

### DIFF
--- a/cmd/formula-analytics.rb
+++ b/cmd/formula-analytics.rb
@@ -371,7 +371,7 @@ module Homebrew
         format("%<percent>.2f", percent:).gsub(/\.00$/, "")
       end
 
-      sig { params(dimension: String).returns(T.nilable(String)) }
+      sig { params(dimension: T.nilable(String)).returns(T.nilable(String)) }
       def format_os_version_dimension(dimension)
         return if dimension.blank?
 


### PR DESCRIPTION
```
Error: Parameter 'dimension': Expected type String, got type NilClass
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-formula-analytics/cmd/formula-analytics.rb:248
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-formula-analytics/cmd/formula-analytics.rb:375
```
