### PR TITLE
Add a comment for rubocop disable comment

### DIFF
--- a/lib/pycall-setup.rb
+++ b/lib/pycall-setup.rb
@@ -2,6 +2,11 @@
 # frozen_string_literal: true
 
 require "pycall/import"
-include PyCall::Import # rubocop:disable Style/MixinUsage
+# This was a rewrite from `include(Module.new(...))`,
+# to appease Sorbet, so let's keep the existing behaviour
+# and silence RuboCop.
+# rubocop:disable Style/MixinUsage
+include PyCall::Import
+# rubocop:enable Style/MixinUsage
 
 pyfrom "influxdb_client_3", import: :InfluxDBClient3


### PR DESCRIPTION
I'm adding a new RuboCop in https://github.com/Homebrew/brew/pull/18842 and CI for that is failing because this line doesn't conform to the cop.

By adding a comment explaining why the cop was disable, the linter is appeased. I cribbed the comment from https://github.com/Homebrew/homebrew-formula-analytics/commit/9780d547f01c24339e4bd1b998dea372c321d1d3